### PR TITLE
Feature/dockerfile zedsdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.idea/
+*.run
+*.pth
+*.engine
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,12 @@ ENV CUDA_HOME /usr/local/cuda-11.4/
 RUN cd /root && git clone https://github.com/IDEA-Research/Grounded-Segment-Anything.git
 
 WORKDIR /root
-RUN wget --quiet -O ZED_SDK_Tegra_L4T35.3_v4.1.0.zstd.run https://download.stereolabs.com/zedsdk/4.1/l4t35.2/jetsons
-RUN chmod +x ZED_SDK_Tegra_L4T35.3_v4.1.0.zstd.run
+ENV ZED_SDK_INSTALLER=ZED_SDK_Tegra_L4T35.3_v4.1.0.zstd.run
+RUN wget --quiet -O ${ZED_SDK_INSTALLER} https://download.stereolabs.com/zedsdk/4.1/l4t35.2/jetsons
+RUN chmod +x ${ZED_SDK_INSTALLER}
 RUN apt update
 RUN apt install zstd
-RUN ./ZED_SDK_Tegra_L4T35.3_v4.1.0.zstd.run -- silent
+RUN ./${ZED_SDK_INSTALLER} -- silent
 
 RUN apt update && apt install -y --no-install-recommends wget ffmpeg=7:* \
     libsm6=2:* libxext6=2:* git=1:* \


### PR DESCRIPTION
# why
- ZED SDK との組合せた環境をDockerで準備をする。
# what
- ZED SDK をDockerfile 中でインストールする。
# 動作確認
- 従来のgrounded SAM のサンプルが動くことを確認する。
- zed sdk をimport してversionの表示ができることを確認する。