### PR TITLE
use fixed string for TORCH_CUDA_ARCH_LIST

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG USE_CUDA=1
 
 ENV AM_I_DOCKER True
 ENV BUILD_WITH_CUDA "${USE_CUDA}"
-ENV TORCH_CUDA_ARCH_LIST "${TORCH_ARCH}"
+ENV TORCH_CUDA_ARCH_LIST "8.7+PTX"
 ENV CUDA_HOME /usr/local/cuda-11.4/
 RUN cd /root && git clone https://github.com/IDEA-Research/Grounded-Segment-Anything.git
 


### PR DESCRIPTION
# why
- 動作環境によってdocker build に成功しない。
- `${TORCH_ARCH}` の環境変数が動作環境によって取得できない。
# what
- `TORCH_CUDA_ARCH_LIST` を固定値で指定した。
## 動作検証
以下のスクリプトが動作することで、GroundingDinoの動作などを検証している。
- `bash test_pre-captured.sh`
- `python3 depth_and_gsam.py`
